### PR TITLE
Add CTE MTF model for CCD detectors

### DIFF
--- a/docs/models/sharpness/opticks_mtf.md
+++ b/docs/models/sharpness/opticks_mtf.md
@@ -30,6 +30,7 @@ The following MTF types are supported:
 - Detector Diffusion ({py:meth}`.MTF_Model_1D.detector_diffusion`): Carrier diffusion MTF model (Crowell & Labuda 1969), with five geometry/boundary variants
 - Detector Diffusion Preset ({py:meth}`.MTF_Model_1D.detector_diffusion_preset`): Detector diffusion MTF from a predefined detector category (BSI CCD, BSI sCMOS, BSI IR FPA, FSI CMOS, FSI CCD)
 - Detector Crosstalk ({py:meth}`.MTF_Model_1D.detector_crosstalk`): Nearest-neighbour crosstalk MTF model with separate side and diagonal coupling coefficients
+- Detector CTE ({py:meth}`.MTF_Model_1D.detector_cte`): Charge transfer efficiency MTF for CCDs (direction-dependent — instantiate one model per direction)
 - Motion Blur ({py:meth}`.MTF_Model_1D.motion_blur`): Motion blur MTF model
 - Drift/Smear ({py:meth}`.MTF_Model_1D.smear`): Drift/Smear MTF model, the more generalised form of motion blur
 - Jitter ({py:meth}`.MTF_Model_1D.jitter`): Jitter MTF model
@@ -38,7 +39,7 @@ The following MTF types are supported:
 
 The full [System MTF example](../examples/sat_mtf_budget.ipynb) illustrates the use of almost all of them. "Slicing an External 2D MTF" is explained in the next section, as it enables detailed Wavefront models to be incorporated.
 
-## Detector Diffusion and Crosstalk MTF
+## Detector Diffusion, Crosstalk, and CTE MTF
 
 ### Detector Diffusion MTF
 
@@ -99,6 +100,59 @@ When only side crosstalk is relevant (the common case), omit `crosstalk_xd` or p
 ```{note}
 The diffusion MTF and the electrical component of crosstalk describe the same underlying physics. Do not multiply them in an MTF budget unless the crosstalk coefficient refers to optical crosstalk only. See [Detector MTF](sharpness_pt2_det.md) for guidance.
 ```
+
+### Detector CTE MTF
+
+The CTE MTF models charge transfer inefficiency in CCD detectors. During readout, charge is clocked through neighbouring pixels toward the output amplifier; each transfer leaves a small fraction behind in silicon traps. The effect is cumulative and **strictly directional** — it produces an asymmetric tail on every point source pointing away from the readout register. Unlike diffusion (isotropic) or aperture (symmetric), CTE blur applies only along the clocking axis.
+
+$$\text{MTF}_\text{CTE}(f) = \exp\!\left(-N(1-\varepsilon)\!\left(1 - \cos\!\left(\frac{\pi f}{f_\text{nyq}}\right)\right)\right)$$
+
+where $N = (\text{num\_pixels} + \text{tdi\_stages}) \times \text{num\_phases}$, $\varepsilon$ = CTE per transfer, and $f_\text{nyq} = 1/(2p)$.
+
+**CTE MTF is not constant across the image** — it degrades roughly linearly from pixels nearest the readout (sharp) to those at the far end (blurry). This is why `num_pixels` is a runtime argument, not a fixed sensor property: instantiate one model per pixel position of interest.
+
+```python
+from opticks import u
+from opticks.contrast_model.mtf import MTF_Model_1D
+
+pitch = 13 * u.um
+
+# Non-TDI 3-phase CCD: ALT (parallel register), worst-case pixel
+mtf_cte_alt = MTF_Model_1D.detector_cte(
+    pixel_pitch=pitch,
+    num_pixels=4096,   # rows from pixel to readout edge
+    num_phases=3,      # 3-phase CCD
+    cte=0.99999,       # high-quality CTE (not CTI — pass 0.99999, not 0.00001)
+)
+
+# TDI CCD with 32 on-chip analog stages: ALT only — each stage adds transfers
+mtf_cte_alt_tdi = MTF_Model_1D.detector_cte(
+    pixel_pitch=pitch,
+    num_pixels=4096,
+    num_phases=3,
+    cte=0.99999,
+    tdi_stages=32,     # analog TDI stages in the parallel register
+)
+
+# ACT (across-track) MTF — serial register only, no TDI
+mtf_cte_act = MTF_Model_1D.detector_cte(
+    pixel_pitch=pitch,
+    num_pixels=6000,   # columns from pixel to readout amplifier
+    num_phases=3,
+    cte=0.99999,
+)
+```
+
+```{note}
+`tdi_stages` applies only to **on-chip analog TDI** in CCDs, where each stage is a real charge transfer in the parallel register. For **digital ("shift-and-add") TDI** — CMOS sensors that read out each row independently and accumulate in firmware — set `tdi_stages = 0`, since no charge transfer occurs between stages. TDI is also parallel-register only, so always pass `tdi_stages = 0` for the ACT direction.
+```
+
+**Radiation aging.** Space radiation creates traps in the silicon lattice that capture and re-emit electrons, increasing CTI ($1 - \varepsilon$) over the mission lifetime. EO satellite MTF budgets should use the predicted End-of-Life (EOL) CTE, not the launch (BOL) value.
+
+| Condition | CTE ($\varepsilon$) | Inefficiency $1-\varepsilon$ | MTF at Nyquist ($N=2000$) |
+| --- | --- | --- | --- |
+| High quality (BOL) | $0.999999$ | $10^{-6}$ | $\approx 0.996$ (negligible) |
+| Degraded (EOL, post-radiation) | $0.99995$ | $5 \times 10^{-5}$ | $\approx 0.818$ (severe) |
 
 ## Point Spread Functions and Optics MTF
 

--- a/docs/models/sharpness/sharpness_pt2_det.md
+++ b/docs/models/sharpness/sharpness_pt2_det.md
@@ -210,7 +210,7 @@ where:
 - $p$ is pixel pitch
 - $f$ is the spatial frequency
 
-It is also possible to convert the equation to Nyquist frequency, where $f_{ny}= 1 / 2p$.
+It is also possible to write the equation in terms of Nyquist frequency, where $f_{ny}= 1 / 2p$.
 
 Note that, Boreman [^2] uses a reversed terminology, where $\varepsilon$ is the fractional charge left behind at each transfer, or CTI as defined here.
 

--- a/docs/models/sharpness/sharpness_pt2_det.md
+++ b/docs/models/sharpness/sharpness_pt2_det.md
@@ -159,6 +159,12 @@ Taking a 1D slice along one axis ($f_y = 0$) yields:
 
 $$\text{MTF}_\text{xtalk}(f) = 1 - 2(X_s + 2X_d)\left(1 - \cos(2\pi f p)\right)$$
 
+This is equivalently written in terms of the Nyquist frequency $f_\text{nyq} = 1/(2p)$:
+
+$$\text{MTF}_\text{xtalk}(f) = 1 - 2(X_s + 2X_d)\!\left(1 - \cos\!\left(\frac{\pi f}{f_\text{nyq}}\right)\right)$$
+
+since $2\pi f p = \pi f / f_\text{nyq}$. The Nyquist form is numerically preferable when $f_\text{nyq}$ is known directly, as the ratio $f/f_\text{nyq}$ is dimensionless.
+
 When diagonal crosstalk is negligible ($X_d = 0$), this reduces to the classical formula $\text{MTF}_\text{xtalk}(f) = 1 - 2X_s(1 - \cos(2\pi f p))$.
 
 This model has the property that:
@@ -210,11 +216,29 @@ where:
 - $p$ is pixel pitch
 - $f$ is the spatial frequency
 
-It is also possible to write the equation in terms of Nyquist frequency, where $f_{ny}= 1 / 2p$.
+It is also possible to write the equation in terms of Nyquist frequency $f_\text{nyq} = 1/(2p)$:
 
-Note that, Boreman [^2] uses a reversed terminology, where $\varepsilon$ is the fractional charge left behind at each transfer, or CTI as defined here.
+$$\text{MTF}_\text{CTE}(f) = \exp\!\left(-N(1-\varepsilon)\!\left(1 - \cos\!\left(\frac{\pi f}{f_\text{nyq}}\right)\right)\right)$$
+
+This form is numerically preferable because the ratio $f / f_\text{nyq}$ is dimensionless and avoids unit-conversion ambiguity when the Nyquist frequency is known directly.
+
+```{note}
+Boreman [^2] uses a reversed terminology, where $\varepsilon$ is the fractional charge left behind at each transfer (i.e., CTI = $1 - \text{CTE}$). In this document, $\varepsilon$ is the CTE — the fraction successfully transferred. The `MTF_Model_1D.detector_cte` factory uses the same convention: pass `cte=0.99999`, not `cte=0.00001`.
+```
 
 At zero frequency ($f = 0$), the cosine term equals 1 and the MTF is unity — charge is conserved overall. The worst degradation occurs at the Nyquist frequency, where the cosine term equals $-1$, giving $\text{MTF} = \exp(-2N(1-\varepsilon))$.
+
+**One-directional smear.** CTE blur is strictly directional — opposite to the charge transfer direction. Unlike diffusion (isotropic) or aperture (symmetric), CTE produces an asymmetric tail on every point source pointing away from the readout register. In a pushbroom imager this contributes only along the clocking axis: parallel-register clocking drives the ALT CTE MTF; serial-register clocking drives the ACT CTE MTF.
+
+**Position-dependence.** The number of transfers $N$ depends on the pixel's position — pixels close to the readout amplifier undergo few transfers and are sharp, while pixels at the far end undergo $N_\text{max}$ transfers and are most degraded. The CTE MTF therefore varies roughly linearly across the image strip. In `opticks` this is exposed by passing `num_pixels` at runtime, not via `SensorParams`.
+
+**TDI as a transfer multiplier.** For on-chip analog TDI CCDs, charge accumulates through extra parallel-register transfers before reaching the readout register:
+
+$$N = (\text{num\_pixels} + \text{tdi\_stages}) \times \text{num\_phases}$$
+
+This applies only to **on-chip analog TDI** (where each stage is a real charge transfer in silicon). **Digital ("shift-and-add") TDI** — the CMOS approach where each row is read out independently and summed in firmware after the ADC — performs no charge transfer between stages, so no extra transfers contribute to CTE degradation.
+
+**Connection to crosstalk MTF.** The CTE MTF and crosstalk MTF share the same $(1 - \cos)$ kernel. This is not a coincidence: CTE can be viewed as *temporal crosstalk* — instead of charge leaking into a spatial neighbour, a fraction leaks into the next read cycle (the temporal neighbour). The compounding over $N$ transfers turns the linear $(1 - \cos)$ factor into the exponential of the closed-form CTE expression.
 
 #### CTE Values and Impact
 

--- a/opticks/contrast_model/detector_mtf.py
+++ b/opticks/contrast_model/detector_mtf.py
@@ -161,16 +161,22 @@ def validate_diffusion_params(
             )
 
 
-def _check_mtf_range(mtf_array: NDArray[np.float64], model_id: str) -> None:
+def _check_mtf_range(mtf_value: float | NDArray[np.float64], model_id: str) -> None:
     """Raise ValueError if any MTF value is outside [0, 1]."""
-    if np.any(mtf_array > 1) or np.any(mtf_array < 0):
-        max_val = np.max(mtf_array)
-        min_val = np.min(mtf_array)
-        raise ValueError(
-            f"MTF out of range [0, 1] for model '{model_id}': "
-            f"min={min_val:.6g}, max={max_val:.6g}. "
-            f"Check physical parameters."
-        )
+    if np.ndim(mtf_value) == 0:
+        if not (0.0 <= float(mtf_value) <= 1.0):
+            raise ValueError(
+                f"MTF out of range [0, 1] for model '{model_id}': "
+                f"value={float(mtf_value):.6g}. "
+                f"Check physical parameters."
+            )
+    else:
+        if np.any(mtf_value > 1) or np.any(mtf_value < 0):
+            raise ValueError(
+                f"MTF out of range [0, 1] for model '{model_id}': "
+                f"min={np.min(mtf_value):.6g}, max={np.max(mtf_value):.6g}. "
+                f"Check physical parameters."
+            )
 
 
 # ---------- collection efficiency (eta) functions ----------

--- a/opticks/contrast_model/detector_mtf.py
+++ b/opticks/contrast_model/detector_mtf.py
@@ -379,17 +379,15 @@ def detector_crosstalk_mtf(
     float | NDArray[np.float64]
         Crosstalk MTF value(s).
     """
-    # phase = f * p, carried as a ``cycle``-typed Quantity so np.cos absorbs
-    # the factor of 2π implicitly (1 cycle ≡ 2π rad).
-    cos_x = np.cos(fx * pixel_pitch)
-    cos_y = np.cos(fy * pixel_pitch)
+    f_nyq = u.cy / (2 * pixel_pitch)
+    cos_x = np.cos(np.pi * (fx / f_nyq).decompose().value * u.rad)
+    cos_y = np.cos(np.pi * (fy / f_nyq).decompose().value * u.rad)
     mtf = (1 - 4 * xs - 4 * xd) + 2 * xs * (cos_x + cos_y) + 4 * xd * cos_x * cos_y
 
-    mtf_array = np.atleast_1d(np.asarray(mtf, dtype=float))
-    _check_mtf_range(mtf_array, f"crosstalk (xs={xs}, xd={xd})")
+    _check_mtf_range(mtf, f"crosstalk (xs={xs}, xd={xd})")
 
     scalar_input = np.ndim(fx) == 0 and np.ndim(fy) == 0
-    return float(mtf_array[0]) if scalar_input else mtf_array
+    return float(mtf) if scalar_input else np.asarray(mtf, dtype=float)
 
 
 def detector_crosstalk_mtf_1d(

--- a/opticks/contrast_model/detector_mtf.py
+++ b/opticks/contrast_model/detector_mtf.py
@@ -482,7 +482,7 @@ def detector_cte_mtf_1d(
     """
     num_transfers = (num_pixels + tdi_stages) * num_phases
     f_nyq = u.cy / (2 * pixel_pitch)
-    cos_term = np.cos(np.pi * (input_line_freq / f_nyq).decompose())
+    cos_term = np.cos(np.pi * (input_line_freq / f_nyq).decompose() * u.rad)
     arg = num_transfers * (1.0 - cte) * (1.0 - cos_term)
     mtf = np.exp(-arg)
     _check_mtf_range(mtf, f"cte (N={num_transfers}, cte={cte:.6g})")

--- a/opticks/contrast_model/detector_mtf.py
+++ b/opticks/contrast_model/detector_mtf.py
@@ -6,9 +6,13 @@
 """
 Detector-level MTF models (diffusion, CTE, crosstalk, etc.).
 
-Currently includes diffusion MTF based on Crowell & Labuda (1969)
-with five simplified cases covering BSI and FSI detector geometries,
-plus preset parameter sets for common detector categories.
+Currently includes:
+
+- Diffusion MTF based on Crowell & Labuda (1969) with five simplified cases
+  covering BSI and FSI detector geometries, plus preset parameter sets for
+  common detector categories.
+- Crosstalk MTF for the center-pixel 8-neighbour model.
+- CTE (Charge Transfer Efficiency) MTF for CCD detectors.
 """
 
 from enum import Enum
@@ -401,3 +405,83 @@ def detector_crosstalk_mtf_1d(
     ``1 - 2Xs(1 - cos(2π f P))``.
     """
     return detector_crosstalk_mtf(input_line_freq, 0 * u.cy / u.mm, xs, xd, pixel_pitch)
+
+
+# ---------- CTE MTF (Charge Transfer Efficiency) ----------
+
+
+def validate_cte_params(
+    num_pixels: int, num_phases: int, cte: float, tdi_stages: int
+) -> None:
+    """Validate parameters for the CTE MTF model.
+
+    Parameters
+    ----------
+    num_pixels : int
+        Number of pixels between the target pixel and the readout register.
+    num_phases : int
+        Number of clock phases per pixel (typically 3 for 3-phase CCDs).
+    cte : float
+        Charge transfer efficiency per transfer (dimensionless, 0 to 1).
+    tdi_stages : int
+        Number of on-chip analog TDI stages (0 for non-TDI or digital TDI).
+    """
+    if num_pixels < 0:
+        raise ValueError(f"num_pixels must be >= 0, got {num_pixels}.")
+    if num_phases < 1:
+        raise ValueError(f"num_phases must be >= 1, got {num_phases}.")
+    if tdi_stages < 0:
+        raise ValueError(f"tdi_stages must be >= 0, got {tdi_stages}.")
+    if not (0.0 <= cte <= 1.0):
+        raise ValueError(f"cte must be in [0, 1], got {cte}.")
+
+
+def detector_cte_mtf_1d(
+    input_line_freq: Quantity,
+    num_pixels: int,
+    num_phases: int,
+    cte: float,
+    pixel_pitch: Quantity,
+    tdi_stages: int = 0,
+) -> float | NDArray[np.float64]:
+    """1D CTE MTF for a CCD detector (Janesick 2001).
+
+    Models charge transfer inefficiency in the parallel or serial register.
+    The MTF degrades with the number of charge transfers and the per-transfer
+    inefficiency (1 - CTE):
+
+        MTF(f) = exp(-N * (1 - cte) * (1 - cos(π f / f_nyq)))
+
+    where N = (num_pixels + tdi_stages) * num_phases and
+    f_nyq = 1 / (2 * pixel_pitch).
+
+    Parameters
+    ----------
+    input_line_freq : Quantity
+        Spatial frequency (e.g. in cy/mm).
+    num_pixels : int
+        Number of pixels between the target pixel and the readout register.
+    num_phases : int
+        Number of clock phases per pixel (typically 3 for 3-phase CCDs).
+    cte : float
+        Charge transfer efficiency per transfer (dimensionless, 0 to 1).
+    pixel_pitch : Quantity["length"]
+        Pixel pitch.
+    tdi_stages : int, optional
+        Number of on-chip analog TDI stages. Default is 0. Pass 0 for
+        digital ("shift-and-add") TDI and for the ACT direction.
+
+    Returns
+    -------
+    float | NDArray[np.float64]
+        CTE MTF value(s).
+    """
+    num_transfers = (num_pixels + tdi_stages) * num_phases
+    f_nyq = u.cy / (2 * pixel_pitch)
+    cos_term = np.cos(np.pi * (input_line_freq / f_nyq).decompose())
+    arg = num_transfers * (1.0 - cte) * (1.0 - cos_term)
+    mtf = np.exp(-arg)
+    _check_mtf_range(mtf, f"cte (N={num_transfers}, cte={cte:.6g})")
+
+    scalar_input = np.ndim(input_line_freq) == 0
+    return float(mtf) if scalar_input else np.asarray(mtf, dtype=float)

--- a/opticks/contrast_model/mtf.py
+++ b/opticks/contrast_model/mtf.py
@@ -19,8 +19,10 @@ from prysm._richdata import RichData
 from opticks import u
 from opticks.contrast_model.detector_mtf import (
     detector_crosstalk_mtf_1d,
+    detector_cte_mtf_1d,
     detector_diffusion_mtf,
     validate_crosstalk_params,
+    validate_cte_params,
     validate_diffusion_params,
 )
 from opticks.contrast_model.optics_mtf import (
@@ -653,6 +655,87 @@ class MTF_Model_1D:
                 crosstalk_xs,
                 crosstalk_xd,
                 pixel_pitch,
+            )
+
+        return MTF_Model_1D(id_str, value_func)
+
+    @staticmethod
+    def detector_cte(
+        pixel_pitch: Quantity,
+        num_pixels: int,
+        num_phases: int,
+        cte: float,
+        tdi_stages: int = 0,
+    ) -> "MTF_Model_1D":
+        """
+        Detector CTE (Charge Transfer Efficiency) MTF model for CCDs.
+
+        Models charge transfer inefficiency in the CCD parallel or serial
+        register. The MTF degrades with the total number of transfers and the
+        per-transfer inefficiency (1 - CTE):
+
+            MTF(f) = exp(-N * (1 - cte) * (1 - cos(π f / f_nyq)))
+
+        where N = (num_pixels + tdi_stages) * num_phases and
+        f_nyq = 1 / (2 * pixel_pitch).
+
+        **CCD only.** CMOS and IR FPAs read out pixels individually and do not
+        suffer from CTE degradation.
+
+        **Direction-dependent.** Instantiate one model per direction:
+
+        - *ALT MTF* (parallel register): ``num_pixels`` = rows from pixel to
+          readout edge; ``tdi_stages`` = number of on-chip analog TDI stages
+          (0 for non-TDI sensors).
+        - *ACT MTF* (serial register): ``num_pixels`` = columns from pixel to
+          readout amplifier; ``tdi_stages = 0`` (TDI is parallel-register
+          only).
+
+        **On-chip vs digital TDI.** ``tdi_stages`` applies only to on-chip
+        analog TDI in CCDs, where each stage is a real charge transfer in the
+        parallel register. For digital ("shift-and-add") TDI — CMOS sensors
+        that read out each row independently and accumulate in firmware —
+        pass ``tdi_stages = 0`` because no charge transfer occurs between
+        stages.
+
+        **Convention.** The ``cte`` parameter follows Janesick (2001): CTE is
+        the fraction of charge successfully transferred per clock cycle
+        (dimensionless, 0 to 1). A high-quality CCD might have
+        ``cte = 0.99999`` (one electron lost per 100 000 transferred).
+        Some references (e.g. Boreman) use ε to mean the inefficiency
+        CTI = 1 − CTE; do not pass ``1 - cte`` here.
+
+        Parameters
+        ----------
+        pixel_pitch : Quantity["length"]
+            Pixel pitch.
+        num_pixels : int
+            Number of pixels between the target pixel and the readout
+            register (position-dependent, direction-dependent).
+        num_phases : int
+            Number of clock phases per pixel (typically 3 for 3-phase CCDs).
+        cte : float
+            Charge transfer efficiency per transfer (dimensionless, 0 to 1).
+            Example: ``cte = 0.99999`` for a high-quality CCD.
+        tdi_stages : int, optional
+            Number of on-chip analog TDI stages. Default is 0.
+
+        Returns
+        -------
+        MTF_Model_1D
+            CTE MTF model.
+        """
+        validate_cte_params(num_pixels, num_phases, cte, tdi_stages)
+
+        id_str = (
+            f"Detector CTE MTF: "
+            f"pixels={num_pixels}, phases={num_phases}, "
+            f"TDI={tdi_stages}, CTE={cte:.6g}, pitch={pixel_pitch}"
+        )
+
+        def value_func(input_line_freq):
+            return detector_cte_mtf_1d(
+                input_line_freq, num_pixels, num_phases, cte, pixel_pitch, tdi_stages
             )
 
         return MTF_Model_1D(id_str, value_func)

--- a/opticks/imager_model/detector.py
+++ b/opticks/imager_model/detector.py
@@ -296,6 +296,13 @@ class SensorParams(BaseModel):
     crosstalk_xs: float | None = None
     crosstalk_xd: float | None = None
 
+    # CTE (Charge Transfer Efficiency) — CCD only
+    cte_num_phases: int | None = None
+    cte_value: float | None = None
+    cte_tdi_stages: int | None = (
+        None  # on-chip analog TDI stages; None or 0 for non-TDI / digital TDI
+    )
+
     # Absorption data file (relative to cwd)
     absorption_data: AbsorptionData | None = None
 
@@ -743,3 +750,76 @@ class Detector(ImagerComponent):
         xd = sp.crosstalk_xd if sp.crosstalk_xd is not None else 0.0
 
         return MTF_Model_1D.detector_crosstalk(pixel_pitch, sp.crosstalk_xs, xd)
+
+    def get_cte_mtf_1d(
+        self,
+        num_pixels: int,
+        channel_id: str,
+        with_binning: bool = True,
+        tdi_stages: int | None = None,
+    ) -> MTF_Model_1D:
+        """Generate CTE MTF model for this detector.
+
+        Uses ``cte_num_phases`` and ``cte_value`` from ``sensor_params`` and
+        the pixel pitch for the given channel.
+
+        ``num_pixels`` is a required runtime argument: the number of pixel
+        shifts from the target pixel to the readout register, which is both
+        position-dependent and direction-dependent. ``cte_tdi_stages`` from
+        ``sensor_params`` is used unless overridden by the *tdi_stages*
+        argument (pass ``tdi_stages=0`` for the ACT direction on a TDI sensor
+        without modifying ``sensor_params``).
+
+        Parameters
+        ----------
+        num_pixels : int
+            Number of pixels between the target pixel and the readout register.
+        channel_id : str
+            Channel identifier.
+        with_binning : bool, optional
+            If ``True`` (default), use the channel's effective pitch accounting
+            for binning. If ``False``, use the native pixel pitch.
+        tdi_stages : int, optional
+            Override for the number of on-chip analog TDI stages. If ``None``,
+            falls back to ``sensor_params.cte_tdi_stages`` (or 0 if unset).
+
+        Returns
+        -------
+        MTF_Model_1D
+            CTE MTF model.
+
+        Raises
+        ------
+        ValueError
+            If ``sensor_params``, ``cte_num_phases``, or ``cte_value`` is not
+            configured.
+        """
+        from opticks.contrast_model.mtf import MTF_Model_1D
+
+        sp = self.sensor_params
+        if sp is None:
+            raise ValueError(
+                "sensor_params is not configured on this Detector. "
+                "Add a sensor_params block to the detector YAML."
+            )
+        if sp.cte_num_phases is None:
+            raise ValueError(
+                "cte_num_phases is not set in sensor_params. "
+                "Add cte_num_phases to the sensor_params block."
+            )
+        if sp.cte_value is None:
+            raise ValueError(
+                "cte_value is not set in sensor_params. "
+                "Add cte_value to the sensor_params block."
+            )
+
+        pixel_pitch = self.get_channel(channel_id).pixel_pitch(
+            with_binning=with_binning
+        )
+        resolved_tdi = (
+            tdi_stages if tdi_stages is not None else (sp.cte_tdi_stages or 0)
+        )
+
+        return MTF_Model_1D.detector_cte(
+            pixel_pitch, num_pixels, sp.cte_num_phases, sp.cte_value, resolved_tdi
+        )

--- a/opticks/imager_model/detector.py
+++ b/opticks/imager_model/detector.py
@@ -677,46 +677,47 @@ class Detector(ImagerComponent):
                 "Neither diffusion_model nor diffusion_preset is set in sensor_params."
             )
 
-    def get_det_sampling_mtf_1d(self, channel_id: str | None = None) -> MTF_Model_1D:
+    def get_det_sampling_mtf_1d(
+        self, channel_id: str, with_binning: bool = True
+    ) -> MTF_Model_1D:
         """Generate detector sampling MTF model for this detector.
 
-        The sampling MTF is a sinc function of the effective pixel pitch.
-        If a channel ID is supplied, the channel's effective pitch (native pitch
-        × binning factor) is used. If no channel is supplied, the native
-        detector pixel pitch is used.
+        The sampling MTF is a sinc function of the effective pixel pitch for
+        the given channel.
 
         Parameters
         ----------
-        channel_id : str, optional
-            Channel identifier. If provided, the channel's effective pixel pitch
-            (accounting for binning) is used. If ``None``, the native detector
-            pixel pitch is used.
+        channel_id : str
+            Channel identifier.
+        with_binning : bool, optional
+            If ``True`` (default), use the channel's effective pitch accounting
+            for binning. If ``False``, use the native pixel pitch.
 
         Returns
         -------
         MTF_Model_1D
             Detector sampling MTF model.
         """
-
-        if channel_id is not None:
-            pixel_pitch = self.get_channel(channel_id).pixel_pitch(with_binning=True)
-        else:
-            pixel_pitch = self.pixel_pitch
-
+        pixel_pitch = self.get_channel(channel_id).pixel_pitch(
+            with_binning=with_binning
+        )
         return MTF_Model_1D.detector_sampling(pixel_pitch)
 
-    def get_crosstalk_mtf_1d(self, channel_id: str | None = None) -> MTF_Model_1D:
+    def get_crosstalk_mtf_1d(
+        self, channel_id: str, with_binning: bool = True
+    ) -> MTF_Model_1D:
         """Generate crosstalk MTF model for this detector.
 
         Uses the crosstalk coefficients from ``sensor_params`` and the pixel
-        pitch (optionally adjusted for binning via *channel_id*).
+        pitch for the given channel.
 
         Parameters
         ----------
-        channel_id : str, optional
-            Channel identifier. If provided, the channel's effective pixel
-            pitch (accounting for binning) is used. If ``None``, the native
-            detector pixel pitch is used.
+        channel_id : str
+            Channel identifier.
+        with_binning : bool, optional
+            If ``True`` (default), use the channel's effective pitch accounting
+            for binning. If ``False``, use the native pixel pitch.
 
         Returns
         -------
@@ -742,11 +743,9 @@ class Detector(ImagerComponent):
                 "Add crosstalk_xs to the sensor_params block."
             )
 
-        if channel_id is not None:
-            pixel_pitch = self.get_channel(channel_id).pixel_pitch(with_binning=True)
-        else:
-            pixel_pitch = self.pixel_pitch
-
+        pixel_pitch = self.get_channel(channel_id).pixel_pitch(
+            with_binning=with_binning
+        )
         xd = sp.crosstalk_xd if sp.crosstalk_xd is not None else 0.0
 
         return MTF_Model_1D.detector_crosstalk(pixel_pitch, sp.crosstalk_xs, xd)

--- a/opticks/imager_model/pupil.py
+++ b/opticks/imager_model/pupil.py
@@ -403,9 +403,8 @@ def _compute_psf(
         # Note: focusing changes aperture sampling,
         # and is a function of wavelength. Therefore we use fixed sampling
         # for multiple wavelengths.
-        coherent_psf = pupil.focus_fixed_sampling(
-            focal_length_val, psf_dx_val, psf_samples
-        )
+        mdft = pupil.prepare_executor(focal_length_val, psf_dx_val, psf_samples)
+        coherent_psf = pupil.focus_dft(mdft)
         psf_data = coherent_psf.intensity.data
         # sum of intensities, wvls are incoherent to each other
         psf_components.append(psf_data)

--- a/tests/contrast_model/test_mtf.py
+++ b/tests/contrast_model/test_mtf.py
@@ -547,3 +547,193 @@ class TestMTF:
                 crosstalk_xs=0.2,
                 crosstalk_xd=0.1,
             )
+
+    # --- Detector CTE MTF tests ---
+
+    def test_mtf_cte_basic(self):
+        """Basic CTE MTF value against analytic truth (num_phases=1 keeps N=num_pixels)."""
+        # N=500, cte=0.99999, p=13 um, f=30 cy/mm -> 0.991186502379679
+        truth = 0.991186502379679
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=13 * u.um,
+            num_pixels=500,
+            num_phases=1,
+            cte=0.99999,
+        )
+
+        assert mtf_model.mtf_value(30 * u.cy / u.mm) == pytest.approx(truth, rel=1e-9)
+
+    def test_mtf_cte_at_zero_freq(self):
+        """CTE MTF is 1.0 at zero frequency for any valid parameters."""
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=13 * u.um,
+            num_pixels=500,
+            num_phases=3,
+            cte=0.99999,
+        )
+
+        assert mtf_model.mtf_value(0 * u.cy / u.mm) == pytest.approx(1.0)
+
+    def test_mtf_cte_at_nyquist(self):
+        """At Nyquist (f=1/2p), MTF = exp(-2 * N * (1 - cte))."""
+        num_pixels, num_phases, cte = 500, 3, 0.99999
+        pitch = 13 * u.um
+        N = num_pixels * num_phases
+        f_nyq = 1 / (2 * pitch.to(u.mm).value) * u.cy / u.mm  # pyright: ignore[reportAttributeAccessIssue]
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=num_pixels,
+            num_phases=num_phases,
+            cte=cte,
+        )
+
+        expected = np.exp(-2 * N * (1 - cte))
+        assert mtf_model.mtf_value(f_nyq) == pytest.approx(expected, rel=1e-12)
+
+    def test_mtf_cte_perfect(self):
+        """CTE = 1.0 gives MTF = 1.0 at all frequencies."""
+        freqs = np.linspace(0, 38, 50) * u.cy / u.mm
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=13 * u.um,
+            num_pixels=4096,
+            num_phases=3,
+            cte=1.0,
+        )
+
+        assert_allclose(mtf_model.mtf_value(freqs), 1.0, rtol=1e-12)
+
+    def test_mtf_cte_no_transfers(self):
+        """num_pixels=0 (zero transfers) gives MTF = 1.0 at all frequencies."""
+        freqs = np.linspace(0, 38, 50) * u.cy / u.mm
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=13 * u.um,
+            num_pixels=0,
+            num_phases=3,
+            cte=0.99999,
+        )
+
+        assert_allclose(mtf_model.mtf_value(freqs), 1.0, rtol=1e-12)
+
+    def test_mtf_cte_array_input(self):
+        """Array frequency input matches analytic formula element-wise."""
+        num_pixels, num_phases, cte = 500, 1, 0.99999
+        pitch = 13 * u.um
+        p_mm = pitch.to(u.mm).value  # pyright: ignore[reportAttributeAccessIssue]
+        freqs = np.array([0, 10, 20, 30, 38.46]) * u.cy / u.mm
+        N = num_pixels * num_phases
+        f_nyq = 1 / (2 * p_mm)
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=num_pixels,
+            num_phases=num_phases,
+            cte=cte,
+        )
+
+        expected = np.exp(-N * (1 - cte) * (1 - np.cos(np.pi * freqs.value / f_nyq)))
+        result = mtf_model.mtf_value(freqs)
+        assert_allclose(result, expected, rtol=1e-12)
+
+    def test_mtf_cte_in_range(self):
+        """CTE MTF stays in [0, 1] over a frequency sweep."""
+        freqs = np.linspace(0, 40, 100) * u.cy / u.mm
+
+        mtf_model = MTF_Model_1D.detector_cte(
+            pixel_pitch=13 * u.um,
+            num_pixels=4096,
+            num_phases=3,
+            cte=0.99999,
+        )
+
+        result = mtf_model.mtf_value(freqs)
+        assert np.all(result >= 0)
+        assert np.all(result <= 1)
+
+    def test_mtf_cte_tdi_stages_compound(self):
+        """tdi_stages adds to num_pixels: (4096+0) and (4064+32) give equal MTF."""
+        pitch = 13 * u.um
+        freqs = np.linspace(0, 38, 50) * u.cy / u.mm
+
+        mtf_no_tdi = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=4096,
+            num_phases=3,
+            cte=0.99999,
+            tdi_stages=0,
+        )
+        mtf_with_tdi = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=4064,
+            num_phases=3,
+            cte=0.99999,
+            tdi_stages=32,
+        )
+
+        assert_allclose(
+            mtf_no_tdi.mtf_value(freqs), mtf_with_tdi.mtf_value(freqs), rtol=1e-12
+        )
+
+        # Adding TDI stages at same num_pixels should strictly lower MTF above f=0
+        mtf_base = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=4096,
+            num_phases=3,
+            cte=0.99999,
+            tdi_stages=0,
+        )
+        mtf_tdi = MTF_Model_1D.detector_cte(
+            pixel_pitch=pitch,
+            num_pixels=4096,
+            num_phases=3,
+            cte=0.99999,
+            tdi_stages=32,
+        )
+        freqs_nonzero = np.linspace(1, 38, 50) * u.cy / u.mm
+        assert np.all(
+            mtf_tdi.mtf_value(freqs_nonzero) < mtf_base.mtf_value(freqs_nonzero)
+        )
+
+    def test_mtf_cte_invalid_negative_n(self):
+        """Negative num_pixels raises ValueError."""
+        with pytest.raises(ValueError):
+            MTF_Model_1D.detector_cte(
+                pixel_pitch=13 * u.um,
+                num_pixels=-1,
+                num_phases=3,
+                cte=0.99999,
+            )
+
+    def test_mtf_cte_invalid_negative_tdi(self):
+        """Negative tdi_stages raises ValueError."""
+        with pytest.raises(ValueError):
+            MTF_Model_1D.detector_cte(
+                pixel_pitch=13 * u.um,
+                num_pixels=500,
+                num_phases=3,
+                cte=0.99999,
+                tdi_stages=-1,
+            )
+
+    def test_mtf_cte_invalid_cte_high(self):
+        """CTE > 1.0 raises ValueError."""
+        with pytest.raises(ValueError):
+            MTF_Model_1D.detector_cte(
+                pixel_pitch=13 * u.um,
+                num_pixels=500,
+                num_phases=3,
+                cte=1.001,
+            )
+
+    def test_mtf_cte_invalid_cte_low(self):
+        """CTE < 0 raises ValueError."""
+        with pytest.raises(ValueError):
+            MTF_Model_1D.detector_cte(
+                pixel_pitch=13 * u.um,
+                num_pixels=500,
+                num_phases=3,
+                cte=-0.001,
+            )

--- a/tests/imager_model/sat_pushbroom_data/pan_detector_with_sensor_params.yaml
+++ b/tests/imager_model/sat_pushbroom_data/pan_detector_with_sensor_params.yaml
@@ -34,3 +34,6 @@ sensor_params:
   depletion_depth: 7 um
   absorption_data:
     file: data/absorption/silicon_300k.txt
+  cte_num_phases: 3
+  cte_value: 0.999995
+  cte_tdi_stages: 0

--- a/tests/imager_model/test_detector.py
+++ b/tests/imager_model/test_detector.py
@@ -248,22 +248,6 @@ class TestSensorParams:
         # MTF should be non-increasing
         assert np.all(np.diff(mtf_vals) <= 1e-9)
 
-    def test_yaml_round_trip_with_sensor_params(self, detector):
-        """sensor_params survives a YAML string round trip."""
-
-        yaml_text = detector.to_yaml_text()
-        reloaded = Detector.from_yaml_text(yaml_text)
-
-        orig_sp = detector.sensor_params
-        assert orig_sp is not None
-        sp = reloaded.sensor_params
-        assert sp is not None
-        assert sp.diffusion_model == orig_sp.diffusion_model
-        assert isclose(sp.diffusion_length, orig_sp.diffusion_length)
-        assert orig_sp.absorption_data is not None
-        assert sp.absorption_data is not None
-        assert sp.absorption_data.file == orig_sp.absorption_data.file
-
     def test_missing_sensor_params_raises(self):
         """get_diffusion_mtf_1d raises ValueError when sensor_params is absent."""
 
@@ -328,6 +312,55 @@ class TestSensorParams:
                 diffusion_preset="scientific_ccd",
             )
 
+    def test_yaml_round_trip_with_sensor_params(self, detector):
+        """sensor_params (including CTE fields) survives a YAML string round trip."""
+
+        yaml_text = detector.to_yaml_text()
+        reloaded = Detector.from_yaml_text(yaml_text)
+
+        orig_sp = detector.sensor_params
+        assert orig_sp is not None
+        sp = reloaded.sensor_params
+        assert sp is not None
+        assert sp.diffusion_model == orig_sp.diffusion_model
+        assert isclose(sp.diffusion_length, orig_sp.diffusion_length)
+        assert orig_sp.absorption_data is not None
+        assert sp.absorption_data is not None
+        assert sp.absorption_data.file == orig_sp.absorption_data.file
+        assert sp.cte_num_phases == orig_sp.cte_num_phases
+        assert sp.cte_value == orig_sp.cte_value
+        assert sp.cte_tdi_stages == orig_sp.cte_tdi_stages
+
+    def test_get_cte_mtf_1d_returns_model(self, detector):
+        """get_cte_mtf_1d returns a working MTF_Model_1D."""
+        from opticks.contrast_model.mtf import MTF_Model_1D
+
+        mtf_model = detector.get_cte_mtf_1d(num_pixels=4096, channel_id="pan")
+
+        assert isinstance(mtf_model, MTF_Model_1D)
+        assert mtf_model.mtf_value(0 * u.cy / u.mm) == pytest.approx(1.0)
+
+    def test_get_cte_mtf_1d_tdi_override(self, detector):
+        """tdi_stages override inflates N and lowers MTF compared to no-override."""
+        freq = 20 * u.cy / u.mm
+
+        mtf_no_tdi = detector.get_cte_mtf_1d(
+            num_pixels=4096, channel_id="pan", tdi_stages=0
+        )
+        mtf_with_tdi = detector.get_cte_mtf_1d(
+            num_pixels=4096, channel_id="pan", tdi_stages=32
+        )
+
+        assert mtf_with_tdi.mtf_value(freq) < mtf_no_tdi.mtf_value(freq)
+
+    def test_get_cte_mtf_1d_missing_raises(self, detector):
+        """get_cte_mtf_1d raises ValueError when cte_value is not set."""
+        assert detector.sensor_params is not None
+        detector.sensor_params.cte_value = None
+
+        with pytest.raises(ValueError, match="cte_value"):
+            detector.get_cte_mtf_1d(num_pixels=4096, channel_id="pan")
+
 
 class TestDetectorSamplingMTF:
     @pytest.fixture(scope="class")
@@ -347,13 +380,6 @@ class TestDetectorSamplingMTF:
             Path("binned_test_detector.yaml"), file_directory, alt_file_directory
         )
         return Detector.from_yaml_file(file_path)
-
-    def test_get_det_sampling_mtf_1d_no_channel(self, ms_detector):
-        """No channel supplied → uses native detector pixel pitch."""
-        from opticks.contrast_model.mtf import MTF_Model_1D
-
-        mtf_model = ms_detector.get_det_sampling_mtf_1d()
-        assert isinstance(mtf_model, MTF_Model_1D)
 
     def test_get_det_sampling_mtf_1d_with_channel(self, ms_detector):
         """Channel supplied → returns MTF_Model_1D using channel effective pitch."""
@@ -380,9 +406,6 @@ class TestDetectorSamplingMTF:
         mtf_binned = binned_detector.get_det_sampling_mtf_1d("binned_4x").mtf_value(
             freq
         )
-        mtf_no_channel = binned_detector.get_det_sampling_mtf_1d().mtf_value(freq)
 
         # binned channel (40 µm pitch) drops faster than native (10 µm pitch)
         assert mtf_binned < mtf_native
-        # no channel uses native pitch
-        np.testing.assert_allclose(mtf_no_channel, mtf_native, rtol=1e-9)

--- a/tests/imager_model/test_optics.py
+++ b/tests/imager_model/test_optics.py
@@ -216,7 +216,8 @@ class TestOptics:
 
         # monochromatic psf
         wf = propagation.Wavefront.from_amp_and_phase(amp, phs, wvl0, dx)
-        psf_mono_prysm = wf.focus_fixed_sampling(efl, res_el, res).intensity
+        mdft = wf.prepare_executor(efl, res_el, res)
+        psf_mono_prysm = wf.focus_dft(mdft).intensity
 
         # polychromatic psf
         halfbw = 0.2
@@ -228,9 +229,8 @@ class TestOptics:
         components = []
         for wvl in wvls:
             wf = propagation.Wavefront.from_amp_and_phase(amp, phs, wvl, dx)
-            focused = wf.focus_fixed_sampling(
-                efl, res_el, res
-            )  # 512 samples in the output domain
+            mdft = wf.prepare_executor(efl, res_el, res)
+            focused = wf.focus_dft(mdft)  # 512 samples in the output domain
             components.append(
                 focused.intensity.data
             )  # sum of intensities, wvls are incoherent to each other


### PR DESCRIPTION
Implements MTF_Model_1D.detector_cte — the Janesick CTE MTF formula with explicit num_pixels, num_phases, and tdi_stages parameters. N = (num_pixels + tdi_stages) × num_phases is computed internally, correctly separating pixel position, on-chip analog TDI accumulation, and clock phases.
Integrates into SensorParams (cte_num_phases, cte_value, cte_tdi_stages) and Detector.get_cte_mtf_1d(num_pixels, channel_id, ...) following the diffusion/crosstalk pattern.
Refactors the crosstalk cosine computation to u.cy / (2 * pixel_pitch) with * u.rad to resolve an astropy cycle-unit ambiguity that caused silent errors when Nyquist frequency was constructed directly from pitch.
Refactors _check_mtf_range to handle scalar vs array inputs cleanly without atleast_1d at the call sites.
Makes channel_id a required argument (previously optional None) for get_det_sampling_mtf_1d and get_crosstalk_mtf_1d, adds with_binning parameter — MTF is a channel property, not a detector property.
14 new tests (11 CTE MTF, 3 detector integration). Documentation updated in opticks_mtf.md and sharpness_pt2_det.md with physical context: directionality, position-dependence, on-chip vs digital TDI, radiation aging/BOL–EOL table, and the "temporal crosstalk" framing.